### PR TITLE
delete all personal information when delete account

### DIFF
--- a/MyConference/www/js/controllers.js
+++ b/MyConference/www/js/controllers.js
@@ -909,6 +909,7 @@ angular.module('starter.controllers', ['services', 'ngCordova'])
             template: "{{'Are you sure you want to delete your account?' | translate}}"
           }).then(function (result) {
             if (result) {
+              backendService.updateUserProfile({"visibleByRegisteredUsers": {"name": '', "gName": ''}});
               backendService.connect().then(function () {
                 backendService.deleteAccount(susUser).then(function () {
                   backendService.logout();


### PR DESCRIPTION
keep email field because we use email as ID and BaasBox does not offer
change user name function
