### PR TITLE
change grant permission organizer

### DIFF
--- a/MyConference/tests/unit-tests/login.controller.tests.js
+++ b/MyConference/tests/unit-tests/login.controller.tests.js
@@ -22,6 +22,8 @@ describe('LoginCtrl: ', function () {
     ionicPopupMock,
     translateMock,
     loginDfd,
+    logoutDfd,
+    userDfd,
     eventDfd,
     translateDfd,
     alertDfd;
@@ -38,13 +40,16 @@ describe('LoginCtrl: ', function () {
       password: 'blabla'
     }
     loginDfd = $q.defer();
+    logoutDfd = $q.defer();
+    userDfd = $q.defer();
     eventDfd = $q.defer();
     translateDfd = $q.defer();
     alertDfd = $q.defer();
     backendServiceMock = {
       login: jasmine.createSpy('login spy').and.returnValue(loginDfd.promise),
-      logout: jasmine.createSpy('logout spy').and.returnValue(loginDfd.promise),
+      logout: jasmine.createSpy('logout spy').and.returnValue(logoutDfd.promise),
       applySettingsForCurrentUser: function () {},
+      getUser: jasmine.createSpy('getUser spy').and.returnValue(userDfd.promise),
       getEvents: jasmine.createSpy('getEvents spy').and.returnValue(eventDfd.promise)
     }
     ionicPopupMock = jasmine.createSpyObj('$ionicPopup spy', ['alert'])
@@ -60,6 +65,19 @@ describe('LoginCtrl: ', function () {
   }));
   // tests
   describe('login function ', function () {
+    beforeEach(function () {
+      //simulate successful login
+      userDfd.resolve({
+        data: {
+          user: {
+            status: "blabla"
+          }
+        }
+      });
+      scope.$digest();
+      logoutDfd.resolve([]);
+      scope.$digest();
+    })
     it('should call backendService.login function with the credentials that was inputted by user', function () {
       expect(backendServiceMock.login).toHaveBeenCalledWith('blabla', 'blabla');
     })

--- a/MyConference/www/js/controllers.js
+++ b/MyConference/www/js/controllers.js
@@ -141,6 +141,8 @@ angular.module('starter.controllers', ['services', 'ngCordova'])
               var name = user1.visibleByRegisteredUsers.name;
               console.log(gName, ' ', name);
               backendService.createOrganizer(user).then(function (res) {
+                var organizerEmail = res.email;
+                backendService.grantAllPermission(organizerEmail);
                 $translate('Done!').then(
                   function (res) {
                     $ionicPopup.alert({

--- a/MyConference/www/js/services.js
+++ b/MyConference/www/js/services.js
@@ -207,8 +207,13 @@ services.factory('backendService', function ($rootScope, $q, $filter) {
       return BaasBox.save(ev, "events")
         .done(function (res) {
           console.log("res ", res);
-          BaasBox.grantUserAccessToObject("events", res.id, BaasBox.ALL_PERMISSION, "default");
-          BaasBox.grantRoleAccessToObject("events", res.id, BaasBox.ALL_PERMISSION, BaasBox.REGISTERED_ROLE)
+          BaasBox.grantUserAccessToObject("events", res.id, BaasBox.READ_PERMISSION, "default");
+          BaasBox.grantRoleAccessToObject("events", res.id, BaasBox.READ_PERMISSION, BaasBox.REGISTERED_ROLE)
+          BaasBox.loadAllCollection("organizer").done(function (orgcol) {
+            for(i = 0; i < orgcol.length; i++){
+              BaasBox.grantUserAccessToObject("events", res.id, BaasBox.ALL_PERMISSION, orgcol[i].email);
+            }
+          })
         })
         .fail(function (error) {
           console.log("error ", error);
@@ -225,7 +230,12 @@ services.factory('backendService', function ($rootScope, $q, $filter) {
         .done(function (res) {
           console.log("res ", res);
           BaasBox.grantUserAccessToObject("organizer", res.id, BaasBox.READ_PERMISSION, "default");
-          BaasBox.grantRoleAccessToObject("organizer", res.id, BaasBox.ALL_PERMISSION, BaasBox.REGISTERED_ROLE)
+          BaasBox.grantRoleAccessToObject("organizer", res.id, BaasBox.READ_PERMISSION, BaasBox.REGISTERED_ROLE)
+          BaasBox.loadAllCollection("organizer").done(function (orgcol) {
+            for(i = 0; i < orgcol.length; i++){
+              BaasBox.grantUserAccessToObject("organizer", res.id, BaasBox.ALL_PERMISSION, orgcol[i].email);
+            }
+          })
         })
         .fail(function (error) {
           console.log("error ", error);
@@ -256,7 +266,12 @@ services.factory('backendService', function ($rootScope, $q, $filter) {
           console.log("res ", res);
           BaasBox.updateEventAgenda(res, evId);
           BaasBox.grantUserAccessToObject("agenda", res.id, BaasBox.READ_PERMISSION, "default");
-          BaasBox.grantRoleAccessToObject("agenda", res.id, BaasBox.READ_PERMISSION, BaasBox.REGISTERED_ROLE)
+          BaasBox.grantRoleAccessToObject("agenda", res.id, BaasBox.READ_PERMISSION, BaasBox.REGISTERED_ROLE);
+          BaasBox.loadAllCollection("organizer").done(function (orgcol) {
+            for(i = 0; i < orgcol.length; i++){
+              BaasBox.grantUserAccessToObject("agenda", res.id, BaasBox.ALL_PERMISSION, orgcol[i].email);
+            }
+          })
         })
         .fail(function (error) {
           console.log("error ", error);
@@ -324,8 +339,13 @@ services.factory('backendService', function ($rootScope, $q, $filter) {
       return BaasBox.save(event, "events")
         .done(function (res) {
           console.log("res ", res);
-          BaasBox.grantUserAccessToObject("events", res.id, BaasBox.ALL_PERMISSION, "default");
-          BaasBox.grantRoleAccessToObject("events", res.id, BaasBox.ALL_PERMISSION, BaasBox.REGISTERED_ROLE)
+          BaasBox.grantUserAccessToObject("events", res.id, BaasBox.READ_PERMISSION, "default");
+          BaasBox.grantRoleAccessToObject("events", res.id, BaasBox.READ_PERMISSION, BaasBox.REGISTERED_ROLE);
+          BaasBox.loadAllCollection("organizer").done(function (orgcol) {
+            for(i = 0; i < orgcol.length; i++){
+              BaasBox.grantUserAccessToObject("events", res.id, BaasBox.ALL_PERMISSION, orgcol[i].email);
+            }
+          })
         })
         .fail(function (error) {
           console.log("error ", error);
@@ -366,8 +386,8 @@ services.factory('backendService', function ($rootScope, $q, $filter) {
         .done(function (res) {
           console.log("res ", res);
           res = jQuery.parseJSON(res);
-          BaasBox.grantUserAccessToFile(res['data'].id, BaasBox.ALL_PERMISSION, "default");
-          BaasBox.grantRoleAccessToFile(res['data'].id, BaasBox.ALL_PERMISSION, BaasBox.REGISTERED_ROLE);
+          BaasBox.grantUserAccessToFile(res['data'].id, BaasBox.READ_PERMISSION, "default");
+          BaasBox.grantRoleAccessToFile(res['data'].id, BaasBox.READ_PERMISSION, BaasBox.REGISTERED_ROLE);
           backend.updateEvent(eventId, "fileId", res['data'].id)
         })
         .fail(function (error) {
@@ -388,8 +408,8 @@ services.factory('backendService', function ($rootScope, $q, $filter) {
         .done(function (res) {
           console.log("res ", res);
           res = jQuery.parseJSON(res);
-          BaasBox.grantUserAccessToFile(res['data'].id, BaasBox.ALL_PERMISSION, "default");
-          BaasBox.grantRoleAccessToFile(res['data'].id, BaasBox.ALL_PERMISSION, BaasBox.REGISTERED_ROLE);
+          BaasBox.grantUserAccessToFile(res['data'].id, BaasBox.READ_PERMISSION, "default");
+          BaasBox.grantRoleAccessToFile(res['data'].id, BaasBox.READ_PERMISSION, BaasBox.REGISTERED_ROLE);
           backend.updateAgenda(agendaId, "fileId", res['data'].id)
         })
         .fail(function (error) {
@@ -947,6 +967,28 @@ services.factory('backendService', function ($rootScope, $q, $filter) {
     if(organizerListArray == 0) {
       return false;
     }
+  }
+
+  /*
+    Function for granting ALL_PERMISSION to all documents to a user / new organizer
+    collection: events, agenda, organizer
+   */
+  backend.grantAllPermission = function(username) {
+    BaasBox.loadAllCollection("events").done(function (resevent) {
+      for(i = 0; i < resevent.length; i++){
+        BaasBox.grantUserAccessToObject("events", resevent[i].id, BaasBox.ALL_PERMISSION, username);
+      }
+    })
+    BaasBox.loadAllCollection("agenda").done(function (resagenda) {
+      for(i = 0; i < resagenda.length; i++){
+        BaasBox.grantUserAccessToObject("agenda", resagenda[i].id, BaasBox.ALL_PERMISSION, username);
+      }
+    })
+    BaasBox.loadAllCollection("organizer").done(function (resorg) {
+      for(i = 0; i < resorg.length; i++){
+        BaasBox.grantUserAccessToObject("organizer", resorg[i].id, BaasBox.ALL_PERMISSION, username);
+      }
+    })
   }
 
      return backend;

--- a/MyConference/www/js/services.js
+++ b/MyConference/www/js/services.js
@@ -364,9 +364,16 @@ services.factory('backendService', function ($rootScope, $q, $filter) {
      Function for updating an agenda
      */
     backend.updateAgenda = function (agendaId, fieldToUpdate, value) {
-      BaasBox.updateField(agendaId, "agenda", fieldToUpdate, value) //
+      BaasBox.updateField(agendaId, "agenda", fieldToUpdate, value)
         .done(function (res) {
           console.log("Agenda updated ", res);
+          BaasBox.grantUserAccessToObject("agenda", res.id, BaasBox.READ_PERMISSION, "default");
+          BaasBox.grantRoleAccessToObject("agenda", res.id, BaasBox.READ_PERMISSION, BaasBox.REGISTERED_ROLE);
+          BaasBox.loadAllCollection("organizer").done(function (orgcol) {
+            for(i = 0; i < orgcol.length; i++){
+              BaasBox.grantUserAccessToObject("agenda", res.id, BaasBox.ALL_PERMISSION, orgcol[i].email);
+            }
+          })
         })
         .fail(function (error) {
           console.log("Agenda update error ", error);

--- a/MyConference/www/lib/baasbox.js
+++ b/MyConference/www/lib/baasbox.js
@@ -329,6 +329,13 @@ var BaasBox = (function () {
       return BaasBox.loadCollectionWithParams(collection, {page: 0, recordsPerPage: BaasBox.pagelength});
     },
 
+    /*
+    Load all documents in a collection
+     */
+    loadAllCollection: function (collection) {
+      return BaasBox.loadCollectionWithParams(collection);
+    },
+
     loadObject: function (collection, objectId) {
       return $.get(BaasBox.endPoint + '/document/' + collection + '/' + objectId)
     },

--- a/MyConference/www/locales/de.json
+++ b/MyConference/www/locales/de.json
@@ -144,6 +144,6 @@
   "This mail address is already in use.": "Diese Mail-Adresse wurde bereits benutzt.",
   "Add Organizer": "Veranstalter hinzufügen",
   "Enter user email": "Eingeben Benutzername / Email",
-  "This user has already been an organizer": "Dieser Benutzer wurde schon ein Veranstalter",
+  "This user has already added as an organizer": "Dieser Benutzer wurde schon ein Veranstalter",
   "New participant $name $gName is registered for $event": "Neuer Teilnehmer {{name}} {{gName}} hat sich für {{event}} registriert"
 }


### PR DESCRIPTION
improve the security of the application by changing the way of granting permission. Only Organizer and Admin have the ALL_PERMISSION to documents / object in collection: organizer, agenda, events

also need to update this function to collection contact created by @clemens-huebner later
